### PR TITLE
fix data type per issue #60

### DIFF
--- a/app/src/main/java/com/paulmandal/atak/forwarder/comm/commhardware/MeshtasticCommHardware.java
+++ b/app/src/main/java/com/paulmandal/atak/forwarder/comm/commhardware/MeshtasticCommHardware.java
@@ -174,7 +174,9 @@ public class MeshtasticCommHardware extends MessageLengthLimitedCommHardware {
     protected boolean sendMessageSegment(byte[] message, String targetId) {
         prepareToSendMessage(message.length);
 
-        DataPacket dataPacket = new DataPacket(targetId, message);
+        DataPacket dataPacket = new DataPacket(targetId, message,
+                MeshProtos.Data.Type.OPAQUE_VALUE, "^local",
+                System.currentTimeMillis(), 0, MessageStatus.UNKNOWN);
         try {
             mMeshService.send(dataPacket);
             mPendingMessageId = dataPacket.getId();
@@ -489,7 +491,7 @@ public class MeshtasticCommHardware extends MessageLengthLimitedCommHardware {
                 case ACTION_RECEIVED_DATA:
                     DataPacket payload = intent.getParcelableExtra(EXTRA_PAYLOAD);
 
-                    if (payload.getDataType() == MeshProtos.Data.Type.CLEAR_TEXT_VALUE) {
+                    if (payload.getDataType() == MeshProtos.Data.Type.OPAQUE_VALUE) {
                         String message = new String(payload.getBytes());
                         Log.d(TAG, "data: " + message);
                         if (message.startsWith(BCAST_MARKER)) {

--- a/app/src/main/java/com/paulmandal/atak/forwarder/comm/commhardware/MeshtasticCommHardware.java
+++ b/app/src/main/java/com/paulmandal/atak/forwarder/comm/commhardware/MeshtasticCommHardware.java
@@ -175,7 +175,7 @@ public class MeshtasticCommHardware extends MessageLengthLimitedCommHardware {
         prepareToSendMessage(message.length);
 
         DataPacket dataPacket = new DataPacket(targetId, message,
-                MeshProtos.Data.Type.OPAQUE_VALUE, "^local",
+                MeshProtos.Data.Type.OPAQUE_VALUE, DataPacket.ID_LOCAL,
                 System.currentTimeMillis(), 0, MessageStatus.UNKNOWN);
         try {
             mMeshService.send(dataPacket);


### PR DESCRIPTION
This PR fixes issue #60 by changing the plugin's packet type from CLEAR_TEXT (printable, or capable of being displayed on a screen with no further processing) to OPAQUE (just transport it from point A to point B with no other processing or content assumptions).

**! WARNING - BREAKING CHANGE !**

Since the packet type is currently used for packet selection, this change means that the messages from previous versions and future versions of the plugin will be incompatible and reciprocally ignored. 

This should be managed via a documentation update and possibly a user notice.