### PR TITLE
Change how channel members are tracked

### DIFF
--- a/app/src/main/java/com/paulmandal/atak/forwarder/Config.java
+++ b/app/src/main/java/com/paulmandal/atak/forwarder/Config.java
@@ -29,6 +29,7 @@ public class Config {
      */
     public static final int MESHTASTIC_MESSAGE_CHUNK_LENGTH = 200;
     public static final int MESSAGE_AWAIT_TIMEOUT_MS = 60000;
+    public static final int REJECT_STALE_NODE_CHANGE_TIME_MS = 1800000;
 
     /**
      * How long shape/PLI messages live in the cache CotMessageCache (preventing them being resent)

--- a/app/src/main/java/com/paulmandal/atak/forwarder/channel/UserTracker.java
+++ b/app/src/main/java/com/paulmandal/atak/forwarder/channel/UserTracker.java
@@ -8,7 +8,6 @@ import android.widget.Toast;
 import com.paulmandal.atak.forwarder.Config;
 import com.paulmandal.atak.forwarder.comm.commhardware.MeshtasticCommHardware;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -83,39 +82,6 @@ public class UserTracker implements MeshtasticCommHardware.UserListener {
         }
 
         Toast.makeText(mAtakContext, "User discovery broadcast received for " + callsign, Toast.LENGTH_SHORT).show();
-    }
-
-    @Override
-    public void onChannelUsersUpdated(List<NonAtakUserInfo> userInfoList) {
-        List<NonAtakUserInfo> newUsers = new ArrayList<>();
-
-        boolean updatedNonAtakStation = false;
-
-        for (NonAtakUserInfo possiblyNewUser : userInfoList) {
-            boolean userExistsInAtakUserList = maybeUpdateUserBatteryPercentage(possiblyNewUser);
-
-            boolean repeatedUserEntry = newUsers.contains(possiblyNewUser);
-            boolean alreadyKnowAboutStation = mNonAtakStations.contains(possiblyNewUser);
-            if (!userExistsInAtakUserList && !repeatedUserEntry && !alreadyKnowAboutStation) {
-                newUsers.add(possiblyNewUser);
-            }
-
-            if (alreadyKnowAboutStation) {
-                updatedNonAtakStation = true;
-                updateNonAtakStation(possiblyNewUser);
-            }
-        }
-
-        if (newUsers.size() > 0) {
-            for (NonAtakUserInfo user : newUsers) {
-                Log.d(TAG, "Adding new non-ATAK user from Meshtastic: " + user.callsign);
-            }
-            mNonAtakStations.addAll(newUsers);
-        }
-
-        if (newUsers.size() > 0 || updatedNonAtakStation) {
-            notifyChannelMembersUpdateListeners();
-        }
     }
 
     @Override

--- a/app/src/main/java/com/paulmandal/atak/forwarder/comm/commhardware/MeshtasticCommHardware.java
+++ b/app/src/main/java/com/paulmandal/atak/forwarder/comm/commhardware/MeshtasticCommHardware.java
@@ -38,8 +38,6 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import static java.lang.System.currentTimeMillis;
-
 public class MeshtasticCommHardware extends MessageLengthLimitedCommHardware {
     public interface UserListener {
         void onUserDiscoveryBroadcastReceived(String callsign, String meshId, String atakUid);
@@ -183,7 +181,7 @@ public class MeshtasticCommHardware extends MessageLengthLimitedCommHardware {
 
         DataPacket dataPacket = new DataPacket(targetId, message,
                 MeshProtos.Data.Type.OPAQUE_VALUE, DataPacket.ID_LOCAL,
-                currentTimeMillis(), 0, MessageStatus.UNKNOWN);
+                System.currentTimeMillis(), 0, MessageStatus.UNKNOWN);
         try {
             mMeshService.send(dataPacket);
             mPendingMessageId = dataPacket.getId();

--- a/app/src/main/java/com/paulmandal/atak/forwarder/persistence/StateStorage.java
+++ b/app/src/main/java/com/paulmandal/atak/forwarder/persistence/StateStorage.java
@@ -17,7 +17,6 @@ public class StateStorage {
 
     private static final String KEY_PLI_CACHE_PURGE_TIME = "pliCachePurgeTime";
     private static final String KEY_DEFAULT_CACHE_PURGE_TIME = "defaultCachePurgeTime";
-    private static final String KEY_COMM_DEVICE_ADDRESS = "commDeviceAddress";
     private static final String KEY_COMM_DEVICE = "commDevice";
 
     private Context mContext;


### PR DESCRIPTION
* Don't get channel members from `MeshService.getNodes()` instead wait for `NODE_CHANGE` events from Meshtastic
* Drop any `NODE_CHANGE` event from a node that hasn't been seen in >30 mins