### PR TITLE
fix "null island" issue #72

### DIFF
--- a/app/src/main/java/com/paulmandal/atak/forwarder/channel/NonAtakUserInfo.java
+++ b/app/src/main/java/com/paulmandal/atak/forwarder/channel/NonAtakUserInfo.java
@@ -6,14 +6,16 @@ public class NonAtakUserInfo extends UserInfo {
     public double lat;
     public double lon;
     public int altitude;
+    public boolean gpsValid;
     public String shortName;
 
-    public NonAtakUserInfo(String callsign, String meshId, @Nullable Integer batteryPercentage, double lat, double lon, int altitude, String shortName) {
+    public NonAtakUserInfo(String callsign, String meshId, @Nullable Integer batteryPercentage, double lat, double lon, int altitude, boolean gpsValid, String shortName) {
         super(callsign, meshId, null, batteryPercentage);
 
         this.lat = lat;
         this.lon = lon;
         this.altitude = altitude;
+        this.gpsValid = gpsValid;
         this.shortName = shortName;
     }
 }

--- a/app/src/main/java/com/paulmandal/atak/forwarder/comm/commhardware/MeshtasticCommHardware.java
+++ b/app/src/main/java/com/paulmandal/atak/forwarder/comm/commhardware/MeshtasticCommHardware.java
@@ -418,13 +418,15 @@ public class MeshtasticCommHardware extends MessageLengthLimitedCommHardware {
         double lat = 0.0;
         double lon = 0.0;
         int altitude = 0;
+        boolean gpsValid = false;
         Position position = nodeInfo.getValidPosition();
         if (position != null) {
             lat = position.getLatitude();
             lon = position.getLongitude();
             altitude = position.getAltitude();
+            gpsValid = true;
         }
-        return new NonAtakUserInfo(meshUser.getLongName(), meshUser.getId(), nodeInfo.getBatteryPctLevel(), lat, lon, altitude, meshUser.getShortName());
+        return new NonAtakUserInfo(meshUser.getLongName(), meshUser.getId(), nodeInfo.getBatteryPctLevel(), lat, lon, altitude, gpsValid, meshUser.getShortName());
     }
 
     private void updateChannelStatus() {

--- a/app/src/main/java/com/paulmandal/atak/forwarder/nonatak/NonAtakStationCotGenerator.java
+++ b/app/src/main/java/com/paulmandal/atak/forwarder/nonatak/NonAtakStationCotGenerator.java
@@ -1,5 +1,7 @@
 package com.paulmandal.atak.forwarder.nonatak;
 
+import android.util.Log;
+
 import com.atakmap.coremap.cot.event.CotDetail;
 import com.atakmap.coremap.cot.event.CotEvent;
 import com.atakmap.coremap.cot.event.CotPoint;
@@ -88,6 +90,12 @@ public class NonAtakStationCotGenerator implements UserTracker.NonAtakStationUpd
     public void onNonAtakStationUpdated(NonAtakUserInfo nonAtakUserInfo) {
         if (nonAtakUserInfo.callsign.equals(mLocalCallsign)) {
             // Disregard our own station
+            return;
+        }
+
+        if (! nonAtakUserInfo.gpsValid) {
+            // Ignore updates that don't contain a valid GPS point
+            Log.w(TAG, "NON-GPS update ignored");
             return;
         }
 


### PR DESCRIPTION
Fix the bug described in issue #72, where missing GPS coords are replaced with default values 0/0/0, causing an apparent teleportation to Null Island in the Atlantic Ocean. :)

The new boolean flag `gpsValid` indicates *unambiguously* whether or not the node update from Meshtastic did contain a valid GPS location. This flag is set in `MeshtasticCommHardware.java`, then checked further downstream in `NonAtakStationCotGenerator.java`. If `false`, then the node update is ignored. This prevents invalid locations from being treated as valid. 