### PR TITLE
tentative fix for issue #94

### DIFF
--- a/app/src/main/java/com/paulmandal/atak/forwarder/channel/UserTracker.java
+++ b/app/src/main/java/com/paulmandal/atak/forwarder/channel/UserTracker.java
@@ -225,8 +225,10 @@ public class UserTracker implements DiscoveryBroadcastEventHandler.DiscoveryBroa
     }
 
     private void notifyTrackerUpdateListeners(TrackerUserInfo trackerUserInfo) {
+        TrackerUserInfo userInfo = mTrackers.get(mTrackers.indexOf(trackerUserInfo));
+
         for (TrackerUpdateListener listener : mTrackerUpdateListener) {
-            mUiThreadHandler.post(() -> listener.trackerUpdated(trackerUserInfo));
+            mUiThreadHandler.post(() -> listener.trackerUpdated(userInfo));
         }
     }
 


### PR DESCRIPTION
Instead of using the incoming POSITION message directly to draw the tracker (and miss the tracker name, causing issue #94 ), use the locally stored record, which contains both the position (freshly updated) and the tracker name.