### PR TITLE
A few updates from testing mid-June

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
 
-    ext.PLUGIN_VERSION = "1.1.1"
+    ext.PLUGIN_VERSION = "1.1.2"
     ext.ATAK_VERSION = "4.4.0"
 
     // Attempt to read ATAK_VERSION from the environment

--- a/app/src/main/java/com/paulmandal/atak/forwarder/ForwarderConstants.java
+++ b/app/src/main/java/com/paulmandal/atak/forwarder/ForwarderConstants.java
@@ -19,7 +19,7 @@ public class ForwarderConstants {
 
     public static final int DELAY_BEFORE_RESTARTING_MESH_SENDER_AFTER_CHANNEL_CHANGE = 3000;
 
-    public static final int DELAY_BEFORE_RESTARTING_MESH_SENDER_AFTER_TRACKER_WRITE = 10000;
+    public static final int DELAY_BEFORE_RESTARTING_MESH_SENDER_AFTER_TRACKER_WRITE = 3000;
 
     /**
      * Meshtastic Radio Config

--- a/app/src/main/java/com/paulmandal/atak/forwarder/channel/UserTracker.java
+++ b/app/src/main/java/com/paulmandal/atak/forwarder/channel/UserTracker.java
@@ -56,7 +56,7 @@ public class UserTracker implements DiscoveryBroadcastEventHandler.DiscoveryBroa
         mLogger = logger;
 
         discoveryBroadcastEventHandler.setListener(this);
-        trackerEventHandler.setListener(this);
+        trackerEventHandler.addListener(this);
     }
 
     @Override

--- a/app/src/main/java/com/paulmandal/atak/forwarder/comm/meshtastic/TrackerEventHandler.java
+++ b/app/src/main/java/com/paulmandal/atak/forwarder/comm/meshtastic/TrackerEventHandler.java
@@ -2,6 +2,7 @@ package com.paulmandal.atak.forwarder.comm.meshtastic;
 
 import android.content.Context;
 import android.content.Intent;
+import android.util.ArraySet;
 
 import com.geeksville.mesh.DataPacket;
 import com.geeksville.mesh.MeshProtos;
@@ -14,6 +15,8 @@ import com.paulmandal.atak.forwarder.helpers.Logger;
 import com.paulmandal.atak.forwarder.plugin.Destroyable;
 
 import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
 
 public class TrackerEventHandler extends MeshEventHandler {
     public interface TrackerListener {
@@ -24,7 +27,7 @@ public class TrackerEventHandler extends MeshEventHandler {
 
     private static final double LAT_LON_INT_TO_DOUBLE_CONVERSION = 10000000D;
 
-    private TrackerListener mTrackerListener;
+    private CopyOnWriteArraySet<TrackerListener> mTrackerListeners = new CopyOnWriteArraySet<>();
 
     public TrackerEventHandler(Context atakContext,
                                Logger logger,
@@ -40,8 +43,8 @@ public class TrackerEventHandler extends MeshEventHandler {
                 meshSuspendController);
     }
 
-    public void setListener(TrackerListener listener) {
-        mTrackerListener = listener;
+    public void addListener(TrackerListener listener) {
+        mTrackerListeners.add(listener);
     }
 
     @Override
@@ -56,7 +59,7 @@ public class TrackerEventHandler extends MeshEventHandler {
 
                 TrackerUserInfo trackerUserInfo = new TrackerUserInfo(meshUser.getLongName(), meshUser.getId(), null, TrackerUserInfo.NO_LAT_LON_ALT_VALUE, TrackerUserInfo.NO_LAT_LON_ALT_VALUE, TrackerUserInfo.NO_LAT_LON_ALT_VALUE, false, meshUser.getShortName(), System.currentTimeMillis(), meshUser.getTeamValue());
 
-                mTrackerListener.onTrackerUpdated(trackerUserInfo);
+                notifyListeners(trackerUserInfo);
             } catch (InvalidProtocolBufferException e) {
                 mLogger.e(TAG, "NODEINFO_APP message failed to parse");
                 e.printStackTrace();
@@ -69,11 +72,17 @@ public class TrackerEventHandler extends MeshEventHandler {
                 boolean gpsValid = position.getLatitudeI() != 0 || position.getLongitudeI() != 0 || position.getAltitude() != 0;
                 TrackerUserInfo trackerUserInfo = new TrackerUserInfo(UserInfo.CALLSIGN_UNKNOWN, payload.getFrom(), position.getBatteryLevel(), position.getLatitudeI() / LAT_LON_INT_TO_DOUBLE_CONVERSION, position.getLongitudeI() / LAT_LON_INT_TO_DOUBLE_CONVERSION, position.getAltitude(), gpsValid, null, System.currentTimeMillis(), TrackerUserInfo.NO_TEAM_DATA);
 
-                mTrackerListener.onTrackerUpdated(trackerUserInfo);
+                notifyListeners(trackerUserInfo);
             } catch (InvalidProtocolBufferException e) {
                 mLogger.e(TAG, "POSITION_APP message failed to parse");
                 e.printStackTrace();
             }
+        }
+    }
+
+    private void notifyListeners(TrackerUserInfo trackerUserInfo) {
+        for (TrackerListener listener : mTrackerListeners) {
+            listener.onTrackerUpdated(trackerUserInfo);
         }
     }
 }

--- a/app/src/main/java/com/paulmandal/atak/forwarder/comm/meshtastic/TrackerEventHandler.java
+++ b/app/src/main/java/com/paulmandal/atak/forwarder/comm/meshtastic/TrackerEventHandler.java
@@ -55,7 +55,7 @@ public class TrackerEventHandler extends MeshEventHandler {
         if (dataType == Portnums.PortNum.NODEINFO_APP.getNumber()) {
             try {
                 MeshProtos.User meshUser = MeshProtos.User.parseFrom(payload.getBytes());
-                mLogger.d(TAG, "NODEINFO_APP parsed NodeInfo: " + meshUser.getId() + ", longName: " + meshUser.getLongName() + ", shortName: " + meshUser.getShortName());
+                mLogger.i(TAG, "NODEINFO_APP parsed NodeInfo: " + meshUser.getId() + ", longName: " + meshUser.getLongName() + ", shortName: " + meshUser.getShortName());
 
                 TrackerUserInfo trackerUserInfo = new TrackerUserInfo(meshUser.getLongName(), meshUser.getId(), null, TrackerUserInfo.NO_LAT_LON_ALT_VALUE, TrackerUserInfo.NO_LAT_LON_ALT_VALUE, TrackerUserInfo.NO_LAT_LON_ALT_VALUE, false, meshUser.getShortName(), System.currentTimeMillis(), meshUser.getTeamValue());
 
@@ -67,7 +67,7 @@ public class TrackerEventHandler extends MeshEventHandler {
         } else if (dataType == Portnums.PortNum.POSITION_APP.getNumber()) {
             try {
                 MeshProtos.Position position = MeshProtos.Position.parseFrom(payload.getBytes());
-                mLogger.d(TAG, "POSITION_APP parsed position: lat: " + position.getLatitudeI() / LAT_LON_INT_TO_DOUBLE_CONVERSION + ", lon: " + position.getLongitudeI() / LAT_LON_INT_TO_DOUBLE_CONVERSION + ", alt: " + position.getAltitude() + ", batteryLevel: " + position.getBatteryLevel() + ", from: " + payload.getFrom());
+                mLogger.i(TAG, "POSITION_APP parsed position: lat: " + position.getLatitudeI() / LAT_LON_INT_TO_DOUBLE_CONVERSION + ", lon: " + position.getLongitudeI() / LAT_LON_INT_TO_DOUBLE_CONVERSION + ", alt: " + position.getAltitude() + ", batteryLevel: " + position.getBatteryLevel() + ", from: " + payload.getFrom());
 
                 boolean gpsValid = position.getLatitudeI() != 0 || position.getLongitudeI() != 0 || position.getAltitude() != 0;
                 TrackerUserInfo trackerUserInfo = new TrackerUserInfo(UserInfo.CALLSIGN_UNKNOWN, payload.getFrom(), position.getBatteryLevel(), position.getLatitudeI() / LAT_LON_INT_TO_DOUBLE_CONVERSION, position.getLongitudeI() / LAT_LON_INT_TO_DOUBLE_CONVERSION, position.getAltitude(), gpsValid, null, System.currentTimeMillis(), TrackerUserInfo.NO_TEAM_DATA);

--- a/app/src/main/java/com/paulmandal/atak/forwarder/plugin/ui/ForwarderMapComponent.java
+++ b/app/src/main/java/com/paulmandal/atak/forwarder/plugin/ui/ForwarderMapComponent.java
@@ -186,6 +186,7 @@ public class ForwarderMapComponent extends DropDownMapComponent {
                 discoveryBroadcastEventHandler,
                 meshSender,
                 inboundMeshMessageHandler,
+                trackerEventHandler,
                 commandQueue,
                 gson,
                 hashHelper);

--- a/app/src/main/java/com/paulmandal/atak/forwarder/plugin/ui/LogMessageDataAdapter.java
+++ b/app/src/main/java/com/paulmandal/atak/forwarder/plugin/ui/LogMessageDataAdapter.java
@@ -11,6 +11,7 @@ import android.widget.TextView;
 import androidx.annotation.NonNull;
 
 import com.paulmandal.atak.forwarder.R;
+import com.paulmandal.atak.forwarder.helpers.Logger;
 import com.paulmandal.atak.forwarder.plugin.ui.viewmodels.LoggingViewModel;
 
 import java.util.List;
@@ -46,7 +47,24 @@ public class LogMessageDataAdapter extends ArrayAdapter<LoggingViewModel.LogMess
         LoggingViewModel.LogMessage logMessage = mLogMessages.get(position);
 
         ViewHolder holder = (ViewHolder) view.getTag();
-        holder.logMessage.setText(String.format("%s: %s", logMessage.tag, logMessage.message));
+        holder.logMessage.setText(String.format("%s/%s: %s", logMessage.tag, logLevelToStr(logMessage.level), logMessage.message));
         return view;
+    }
+
+    private String logLevelToStr(int level) {
+        switch (level) {
+            case Logger.LOG_LEVEL_VERBOSE:
+                return "V";
+            case Logger.LOG_LEVEL_DEBUG:
+                return "D";
+            case Logger.LOG_LEVEL_INFO:
+                return "I";
+            case Logger.LOG_LEVEL_WARN:
+                return "W";
+            case Logger.LOG_LEVEL_ERROR:
+                return "E";
+            default:
+                return "?";
+        }
     }
 }

--- a/app/src/main/java/com/paulmandal/atak/forwarder/plugin/ui/StatusScreen.java
+++ b/app/src/main/java/com/paulmandal/atak/forwarder/plugin/ui/StatusScreen.java
@@ -124,11 +124,6 @@ public class StatusScreen extends ConstraintLayout {
         statusViewModel.getTimedOutMessages().observe(lifecycleOwner, timedOutMessages -> mTimedOutTextView.setText(String.format("%d", timedOutMessages)));
         statusViewModel.getErroredMessages().observe(lifecycleOwner, erroredMessages -> mErroredTextView.setText(String.format("%d", erroredMessages)));
         statusViewModel.getTotalMessage().observe(lifecycleOwner, totalMessages -> mTotalTextView.setText(String.format("%d", totalMessages)));
-        statusViewModel.getErrorsInARow().observe(lifecycleOwner, errorsInARow -> {
-            if (errorsInARow > 1 && errorsInARow % 5 == 0) {
-                Toast.makeText(atakContext, String.format("%d errors in a row -- maybe out of range, verify your channel settings if you have not been getting messages", errorsInARow), Toast.LENGTH_LONG).show();
-            }
-        });
         statusViewModel.getChannelName().observe(lifecycleOwner, channelName -> mChannelName.setText(channelName != null ? String.format("#%s", channelName) : null));
         statusViewModel.getPskHash().observe(lifecycleOwner, mPskHash::setText);
         statusViewModel.getModemConfig().observe(lifecycleOwner, modemConfig -> mModemConfig.setText(modemConfig != null ? String.format("%d", modemConfig.getNumber()) : null));

--- a/app/src/main/java/com/paulmandal/atak/forwarder/plugin/ui/viewmodels/StatusViewModel.java
+++ b/app/src/main/java/com/paulmandal/atak/forwarder/plugin/ui/viewmodels/StatusViewModel.java
@@ -16,6 +16,7 @@ import com.paulmandal.atak.forwarder.comm.meshtastic.DiscoveryBroadcastEventHand
 import com.paulmandal.atak.forwarder.comm.meshtastic.InboundMeshMessageHandler;
 import com.paulmandal.atak.forwarder.comm.meshtastic.MeshSender;
 import com.paulmandal.atak.forwarder.comm.meshtastic.MeshServiceController;
+import com.paulmandal.atak.forwarder.comm.meshtastic.TrackerEventHandler;
 import com.paulmandal.atak.forwarder.comm.queue.CommandQueue;
 import com.paulmandal.atak.forwarder.helpers.HashHelper;
 import com.paulmandal.atak.forwarder.plugin.Destroyable;
@@ -27,7 +28,8 @@ public class StatusViewModel extends ChannelStatusViewModel implements UserTrack
         CommandQueue.Listener,
         MeshServiceController.ConnectionStateListener,
         MeshSender.MessageAckNackListener,
-        InboundMeshMessageHandler.MessageListener {
+        InboundMeshMessageHandler.MessageListener,
+        TrackerEventHandler.TrackerListener {
     private static final String TAG = ForwarderConstants.DEBUG_TAG_PREFIX + StatusViewModel.class.getSimpleName();
 
     private final DiscoveryBroadcastEventHandler mDiscoveryBroadcastEventHandler;
@@ -48,6 +50,7 @@ public class StatusViewModel extends ChannelStatusViewModel implements UserTrack
                            DiscoveryBroadcastEventHandler discoveryBroadcastEventHandler,
                            MeshSender meshSender,
                            InboundMeshMessageHandler inboundMeshMessageHandler,
+                           TrackerEventHandler trackerEventHandler,
                            CommandQueue commandQueue,
                            Gson gson,
                            HashHelper hashHelper) {
@@ -67,6 +70,7 @@ public class StatusViewModel extends ChannelStatusViewModel implements UserTrack
         meshServiceController.addConnectionStateListener(this);
         meshSender.addMessageAckNackListener(this);
         inboundMeshMessageHandler.addMessageListener(this);
+        trackerEventHandler.addListener(this);
     }
 
     @Override
@@ -149,6 +153,12 @@ public class StatusViewModel extends ChannelStatusViewModel implements UserTrack
 
     @Override
     public void onMessageReceived(int messageId, byte[] message) {
+        mTotalMessages.setValue(mTotalMessages.getValue() + 1);
+        mReceivedMessages.setValue(mReceivedMessages.getValue() + 1);
+    }
+
+    @Override
+    public void onTrackerUpdated(TrackerUserInfo trackerUserInfo) {
         mTotalMessages.setValue(mTotalMessages.getValue() + 1);
         mReceivedMessages.setValue(mReceivedMessages.getValue() + 1);
     }

--- a/app/src/main/java/com/paulmandal/atak/forwarder/plugin/ui/viewmodels/StatusViewModel.java
+++ b/app/src/main/java/com/paulmandal/atak/forwarder/plugin/ui/viewmodels/StatusViewModel.java
@@ -40,7 +40,6 @@ public class StatusViewModel extends ChannelStatusViewModel implements UserTrack
     private final MutableLiveData<Integer> mDeliveredMessages = new MutableLiveData<>();
     private final MutableLiveData<Integer> mTimedOutMessages = new MutableLiveData<>();
     private final MutableLiveData<Integer> mReceivedMessages = new MutableLiveData<>();
-    private final MutableLiveData<Integer> mErrorsInARow = new MutableLiveData<>();
 
     public StatusViewModel(List<Destroyable> destroyables,
                            SharedPreferences sharedPreferences,
@@ -60,7 +59,6 @@ public class StatusViewModel extends ChannelStatusViewModel implements UserTrack
         mTotalMessages.setValue(0);
         mErroredMessages.setValue(0);
         mDeliveredMessages.setValue(0);
-        mErrorsInARow.setValue(0);
         mTimedOutMessages.setValue(0);
         mReceivedMessages.setValue(0);
 
@@ -129,11 +127,6 @@ public class StatusViewModel extends ChannelStatusViewModel implements UserTrack
         return mDeliveredMessages;
     }
 
-    @NonNull
-    public LiveData<Integer> getErrorsInARow() {
-        return mErrorsInARow;
-    }
-
     public void broadcastDiscoveryMessage() {
         mDiscoveryBroadcastEventHandler.broadcastDiscoveryMessage(true);
     }
@@ -142,10 +135,8 @@ public class StatusViewModel extends ChannelStatusViewModel implements UserTrack
     public void onMessageAckNack(int messageId, boolean isAck) {
         mTotalMessages.setValue(mTotalMessages.getValue() + 1);
         if (isAck) {
-            mErrorsInARow.setValue(0);
             mDeliveredMessages.setValue(mDeliveredMessages.getValue() + 1);
         } else {
-            mErrorsInARow.setValue(mErrorsInARow.getValue() + 1);
             mErroredMessages.setValue(mErroredMessages.getValue() + 1);
         }
     }


### PR DESCRIPTION
- Get rid of "X errors in a row" `Toast` message, it's annoying and spams when you're out of range, and the new signal indicator is understandable
- `NODEINFO_APP` and `POSITION_APP` messages count towards the received/total in the status screen
- Reduced the delay after writing to a Tracker to 3s
- Bumped up `NODEINFO_APP` and `POSITION_APP` in logging
- Add logging level indicator to status screen output