### PR TITLE
Bugfixes for the 2.0.2 Release

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,29 +10,29 @@ Binaries signed for the Play Store version of ATAK are available here: [Binaries
 
 ## Share Markers and PLI
 
-![Share Markers and PLI](https://github.com/paulmandal/atak-forwarder/raw/2.0.2/images/0-markers-and-pli.png)
+![Share Markers and PLI](https://github.com/paulmandal/atak-forwarder/raw/2.0.3/images/0-markers-and-pli.png)
 <br>
-![Plugin Status Screen](https://github.com/paulmandal/atak-forwarder/raw/2.0.2/images/1-status.png)
+![Plugin Status Screen](https://github.com/paulmandal/atak-forwarder/raw/2.0.3/images/1-status.png)
 <br>
 <br>
 
 ## Send Chat Messages
 
-![Chat Messages](https://github.com/paulmandal/atak-forwarder/raw/2.0.2/images/2-chat-messages.png)
+![Chat Messages](https://github.com/paulmandal/atak-forwarder/raw/2.0.3/images/2-chat-messages.png)
 <br>
 <br>
 
 ## Configurable Channel Settings / Share with QR
 
-![Channel Mode Selection](https://github.com/paulmandal/atak-forwarder/raw/2.0.2/images/3-channel-config.png)
+![Channel Mode Selection](https://github.com/paulmandal/atak-forwarder/raw/2.0.3/images/3-channel-config.png)
 <br>
-![QR Channel Sharing](https://github.com/paulmandal/atak-forwarder/raw/2.0.2/images/4-qr-code-sharing.png)
+![QR Channel Sharing](https://github.com/paulmandal/atak-forwarder/raw/2.0.3/images/4-qr-code-sharing.png)
 <br>
 <br>
 
 ## Use standalone Meshtastic devices as Trackers
 
-![Write to Tracker](https://github.com/paulmandal/atak-forwarder/raw/2.0.2/images/5-write-to-tracker.png)
+![Write to Tracker](https://github.com/paulmandal/atak-forwarder/raw/2.0.3/images/5-write-to-tracker.png)
 <br>
 <br>
 

--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ The plugin has been tested with these versions of the Meshtastic dependencies. I
 
 | Dependency | Version |
 |--|--|
-| Meshtastic App | 2.0.14 |
-| Meshtastic Firmware | 2.0.14 |
+| Meshtastic App | 2.0.17 |
+| Meshtastic Firmware | 2.0.20 |
 
 # To Do
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
 
-    ext.PLUGIN_VERSION = "2.0.2"
+    ext.PLUGIN_VERSION = "2.0.3"
     ext.ATAK_VERSION = "4.5.0"
 
     // Attempt to read ATAK_VERSION from the environment

--- a/app/src/main/aidl/com/geeksville/mesh/IMeshService.aidl
+++ b/app/src/main/aidl/com/geeksville/mesh/IMeshService.aidl
@@ -61,6 +61,9 @@ interface IMeshService {
     /// Return my unique user ID string
     String getMyId();
 
+    /// Return a unique packet ID
+    int getPacketId();
+
     /*
     Send a packet to a specified node name
 

--- a/app/src/main/java/com/geeksville/mesh/DataPacket.kt
+++ b/app/src/main/java/com/geeksville/mesh/DataPacket.kt
@@ -55,6 +55,13 @@ data class DataPacket(
         else
             null
 
+    constructor(to: String?, channel: Int, waypoint: MeshProtos.Waypoint) : this(
+        to = to,
+        bytes = waypoint.toByteArray(),
+        dataType = Portnums.PortNum.WAYPOINT_APP_VALUE,
+        channel = channel
+    )
+
     val waypoint: MeshProtos.Waypoint?
         get() = if (dataType == Portnums.PortNum.WAYPOINT_APP_VALUE)
             MeshProtos.Waypoint.parseFrom(bytes)
@@ -149,6 +156,7 @@ data class DataPacket(
         const val NODENUM_BROADCAST = (0xffffffff).toInt()
 
         fun nodeNumToDefaultId(n: Int): String = "!%08x".format(n)
+        fun idToDefaultNodeNum(id: String?): Int? = id?.toLong(16)?.toInt()
 
         override fun createFromParcel(parcel: Parcel): DataPacket {
             return DataPacket(parcel)

--- a/app/src/main/java/com/paulmandal/atak/forwarder/comm/meshtastic/MeshDeviceConfigurationController.java
+++ b/app/src/main/java/com/paulmandal/atak/forwarder/comm/meshtastic/MeshDeviceConfigurationController.java
@@ -264,7 +264,10 @@ public class MeshDeviceConfigurationController implements DeviceConnectionHandle
         String meshId = mMeshtasticDevice.address.replace(":", "").toLowerCase();
         String shortMeshId = meshId.replaceAll("!", "").substring(meshId.length() - 4);
         char lastChar = (char) (shortMeshId.charAt(shortMeshId.length() - 1) - 2);
-        shortMeshId = shortMeshId.substring(0, shortMeshId.length() - 1) + lastChar; // TODO: this may be device specific
+        if (lastChar < '0') {
+            lastChar = '0';
+        }
+        shortMeshId = shortMeshId.substring(0, shortMeshId.length() - 1) + lastChar; // TODO: need to find a way to exclude some devices (e.g. RAK)
         mLongName = String.format("%s-MX-%s", mCallsign, shortMeshId);
         mShortName = mCallsign.substring(0, 1);
     }


### PR DESCRIPTION
- Fixes a bug where RAK devices with a Bluetooth address ending in `1` would end up with a `longName` ending in `\` which would break everything. This is not an ideal fix but with no way to differentiate device types at this time it will do.